### PR TITLE
Changing ImageWrapper.h for compilation with UE 4.18

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSimGameMode.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirSimGameMode.cpp
@@ -1,6 +1,6 @@
 #include "AirSimGameMode.h"
 #include "Misc/FileHelper.h"
-#include "ImageWrapper.h"
+#include "IImageWrapperModule.h"
 #include "SimHUD/SimHUD.h"
 #include "common/Common.hpp"
 #include "AirBlueprintLib.h"


### PR DESCRIPTION
The plugin fails to compile with UE 4.18 because the header ImageWrapper.h is not found. 

The header is now called    IImageWrapperModule.h

Changing this header allows the plugin to be included in a new project and compiled.